### PR TITLE
Fix packaging configuration in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/zsteve/pcurvepy",
-    packages=setuptools.find_packages(),
+    py_modules=["pcurve"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This pull request addresses an issue with the packaging configuration in `setup.py`. The current setup uses `setuptools.find_packages()`, which does not include any modules when there is only a single module file (e.g., `pcurve.py`) without an accompanying package directory. As a result, only the `.dist-info` folder is generated, and the actual module is missing from the installation. This change ensures that the module file is correctly included in the installation process.

Testing:
- Installed the package locally using `pip install .`.
- Verified that the module can be successfully imported with `import pcurve` in Python without any errors.

Thank you!